### PR TITLE
fix: TFB | Исправлена версия python в poetry 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["s1veme <kpdpav@gmail.com>"]
 
 
 [tool.poetry.dependencies]
-python = "3.10"
+python = "^3.10"
 Django = "^4.1.6"
 djangorestframework = "^3.14.0"
 environs = "^9.5.0"


### PR DESCRIPTION
Была исправлена следующая ошибка при запуске контейнера:
```
The currently activated Python version 3.10.10 is not supported by the project (3.10).
```

Изменена версия python в файле `pyproject.toml`
Было `3.10`
Стало:  `^3.10`
Теперь версия не строгая и может быть больше `3.10`. 