### PR TITLE
feat: TFB-05 | Добавлено описание ошибок ко всем тестам

### DIFF
--- a/src/api/v1/user/tests/test_view/test_detail_user_view.py
+++ b/src/api/v1/user/tests/test_view/test_detail_user_view.py
@@ -21,10 +21,12 @@ def test_get_detail_user(user_factory) -> None:
     response = api.get(reverse('user-detail', kwargs={'pk': user.id}))
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response_content['id'] == user.id
-    assert response_content['first_name'] == user.first_name
-    assert response_content.get('email') is None
+    assert response.status_code == status.HTTP_200_OK, 'Ожидался 200 статус-код ответа'
+    assert response_content['id'] == user.id, 'ID из тела ответа не равен ID пользователя, который был запрошен'
+    assert (
+        response_content['first_name'] == user.first_name
+    ), 'Имя из тела ответа не равен имени пользователя, который был запрошен'
+    assert response_content.get('email') is None, 'В теле ответа пришёл email, хотя его не ожидалось'
 
 
 def test_get_detail_unauthorized_user(user_factory) -> None:
@@ -35,5 +37,7 @@ def test_get_detail_unauthorized_user(user_factory) -> None:
     response = api.get(reverse('user-detail', kwargs={'pk': user.id}))
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-    assert response_content['detail'] == 'Authentication credentials were not provided.'
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED, 'Ожидался 401 статус-код ответа'
+    assert (
+        response_content['detail'] == 'Authentication credentials were not provided.'
+    ), 'Сообщение в поле "detail" не соответствует ожидаемому'

--- a/src/api/v1/user/tests/test_view/test_me_view.py
+++ b/src/api/v1/user/tests/test_view/test_me_view.py
@@ -21,10 +21,12 @@ def test_get_me(user_factory) -> None:
     response = api.get(reverse('user-me'))
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response_content['id'] == user.id
-    assert response_content['first_name'] == user.first_name
-    assert response_content['email'] == user.email
+    assert response.status_code == status.HTTP_200_OK, 'Ожидался 200 статус-код ответа'
+    assert response_content['id'] == user.id, 'ID из тела ответа не равен ID пользователя, который был запрошен'
+    assert (
+        response_content['first_name'] == user.first_name
+    ), 'Имя из тела ответа не равен имени пользователя, который был запрошен'
+    assert response_content['email'] == user.email, 'В теле ответа нет поля "email", хотя он ожидался'
 
 
 def test_get_me_without_jwt() -> None:
@@ -33,8 +35,10 @@ def test_get_me_without_jwt() -> None:
     response = api.get(reverse('user-me'))
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_401_UNAUTHORIZED
-    assert response_content['detail'] == 'Authentication credentials were not provided.'
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED, 'Ожидалось 401 статус-код ответа'
+    assert (
+        response_content['detail'] == 'Authentication credentials were not provided.'
+    ), 'Сообщение в поле "detail" не соответствует ожидаемому'
 
 
 def test_update_me(user_factory) -> None:
@@ -54,8 +58,10 @@ def test_update_me(user_factory) -> None:
 
     user.refresh_from_db()
 
-    assert response.status_code == status.HTTP_200_OK
-    assert response_content['first_name'] == user.first_name
+    assert response.status_code == status.HTTP_200_OK, 'Ожидался 200 статус-код ответа'
+    assert (
+        response_content['first_name'] == user.first_name
+    ), 'Имя из тела ответа не равен имени пользователя, который был запрошен'
 
 
 def test_invalid_update_me(user_factory) -> None:
@@ -74,8 +80,10 @@ def test_invalid_update_me(user_factory) -> None:
 
     user.refresh_from_db()
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert user.email == old_email
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, 'Ожидался 400 статус-код ответа'
+    assert (
+        user.email == old_email
+    ), 'У пользователя изменилось поле "email", хотя ожидалось, что это поле не будет изменено'
 
 
 def test_delete_me(user_factory) -> None:
@@ -91,5 +99,5 @@ def test_delete_me(user_factory) -> None:
 
     user.refresh_from_db()
 
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-    assert not user.is_active
+    assert response.status_code == status.HTTP_204_NO_CONTENT, 'Ожидался 204 статус-код ответа'
+    assert not user.is_active, 'Ожидалось, что у пользователя поле "is_active" будет равно False'

--- a/src/api/v1/user/tests/test_view/test_register_view.py
+++ b/src/api/v1/user/tests/test_view/test_register_view.py
@@ -20,13 +20,15 @@ def test_user_registration(user_data: dict):
     response = api.post(url, user_data, format='json')
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_201_CREATED
-    assert User.objects.count() == 1
+    assert response.status_code == status.HTTP_201_CREATED, 'Ожидался 201 статус-код ответа'
+    assert User.objects.count() == 1, 'Ожидалось, что количество пользователей в базе данных будет равно 1'
 
     user = User.objects.get(id=response_content['id'])
-    assert user.first_name == user_data['first_name']
-    assert user.password is not None
-    assert user.is_active is True
+    assert (
+        user.first_name == user_data['first_name']
+    ), 'Имя из тела ответа не равен имени пользователя, которое пришло в ответе'
+    assert user.password is not None, 'Ожидалось, что в теле ответа не будет пароля пользователя'
+    assert user.is_active is True, 'Ожидалось, что поле пользователя "is_active" будет равно True'
 
 
 def test_invalid_user_registration(user_data: dict):
@@ -39,6 +41,6 @@ def test_invalid_user_registration(user_data: dict):
     response = api.post(url, invalid_user_data, format='json')
     response_content = response.json()
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert User.objects.count() == 0
-    assert response_content.get('email') is not None
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, 'Ожидался 400 статус-код ответа'
+    assert User.objects.count() == 0, 'Ожидалось, что количество пользователей в базе данных будет равно 0'
+    assert response_content.get('email') is not None, 'Ожидалось, что в теле ответа не будет поля "email"'


### PR DESCRIPTION
Теперь, тесты не просто падают, но ещё и возвращают какое-то описание, чтобы разработчику было проще понять, в чём именно ошибка. 

Было:
```python
assert response.status_code == status.HTTP_200_OK
assert response_content['id'] == user.id
```

Стало:
```python
assert response.status_code == status.HTTP_200_OK, 'Ожидался 200 статус-код ответа'
assert response_content['id'] == user.id, 'ID из тела ответа не равен ID пользователя, который был запрошен'
```

Close #17 