### PR TITLE
fix: TFB-07 | Удален `api/` из auth URL

### DIFF
--- a/src/api/common/auth/urls.py
+++ b/src/api/common/auth/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView, TokenVerifyView
 
 urlpatterns = [
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
-    path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='refresh_token'),
+    path('token/verify/', TokenVerifyView.as_view(), name='verify_token'),
 ]


### PR DESCRIPTION
Был удален `api/` и теперь auth URL'ы выглядят вот так:
`/auth/token`
`/auth/token/refresh`
`/auth/token/verify`

close #21 