### PR TITLE
fix: TFB-21 | Исправлено API для категорий

### DIFF
--- a/src/api/v1/advertisement/tests/test_view/test_advertisement_categories.py
+++ b/src/api/v1/advertisement/tests/test_view/test_advertisement_categories.py
@@ -18,8 +18,8 @@ def test_get_list_categories(api_client, user_factory, advertisement_category_fa
         advertisement_category_factory(title=f'Category {index}')
 
     assert (
-        AdvertisementCategory.objects.count() == 9
-    ), f'Ожидалось, что количество категорий в базе данных будет равно 9, а не {AdvertisementCategory.objects.count()}'
+        AdvertisementCategory.objects.count() == 10
+    ), f'Ожидалось, что количество категорий в базе данных будет равно 10, а не {AdvertisementCategory.objects.count()}'
 
     response = api_client.get(reverse('v1:categories-list'))
     response_json = response.json()
@@ -29,5 +29,5 @@ def test_get_list_categories(api_client, user_factory, advertisement_category_fa
     ), f'Ожидался 200 статус-код ответа, а пришёл {response.status_code}'
 
     assert (
-        len(response_json) == 9
-    ), f'Ожидалось, что количество категорий в ответе будет равно 9, а не {len(response_json)}'
+        len(response_json) == 10
+    ), f'Ожидалось, что количество категорий в ответе будет равно 10, а не {len(response_json)}'

--- a/src/api/v1/advertisement/tests/test_view/test_advertisement_categories.py
+++ b/src/api/v1/advertisement/tests/test_view/test_advertisement_categories.py
@@ -1,0 +1,33 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from apps.advertisement.models import AdvertisementCategory
+from apps.user.models import User
+
+pytestmark = [
+    pytest.mark.django_db,
+]
+
+
+def test_get_list_categories(api_client, user_factory, advertisement_category_factory) -> None:
+    user: User = user_factory()
+    api_client.force_authenticate(user)
+
+    for index in range(10):
+        advertisement_category_factory(title=f'Category {index}')
+
+    assert (
+        AdvertisementCategory.objects.count() == 9
+    ), f'Ожидалось, что количество категорий в базе данных будет равно 9, а не {AdvertisementCategory.objects.count()}'
+
+    response = api_client.get(reverse('v1:categories-list'))
+    response_json = response.json()
+
+    assert (
+        response.status_code == status.HTTP_200_OK
+    ), f'Ожидался 200 статус-код ответа, а пришёл {response.status_code}'
+
+    assert (
+        len(response_json) == 9
+    ), f'Ожидалось, что количество категорий в ответе будет равно 9, а не {len(response_json)}'

--- a/src/api/v1/advertisement/urls.py
+++ b/src/api/v1/advertisement/urls.py
@@ -1,8 +1,11 @@
+from django.urls import path
 from rest_framework import routers
 
-from api.v1.advertisement.views import AdvertisementModelViewSet
+from api.v1.advertisement.views import AdvertisementCategoryListAPIView, AdvertisementModelViewSet
 
 router = routers.SimpleRouter()
 router.register('', AdvertisementModelViewSet, basename='advertisements')
 
-urlpatterns = [] + router.urls
+urlpatterns = [
+    path('categories', AdvertisementCategoryListAPIView.as_view(), name='categories-list'),
+] + router.urls

--- a/src/api/v1/advertisement/views.py
+++ b/src/api/v1/advertisement/views.py
@@ -4,7 +4,7 @@ from rest_framework.viewsets import ModelViewSet
 from api.v1.advertisement import serializers
 from api.v1.advertisement.filters import AdvertisementFilter
 from api.v1.advertisement.serializers import AdvertisementCategorySerializer
-from apps.advertisement.models import Advertisement
+from apps.advertisement.models import Advertisement, AdvertisementCategory
 from apps.user.permissions import IsAuthenticatedAndIsActive
 from utils.mixins.views import SerializerClassMapMixin
 
@@ -22,7 +22,7 @@ class AdvertisementModelViewSet(SerializerClassMapMixin, ModelViewSet):
     filterset_class = AdvertisementFilter
 
 
-class AdvertisementListAPIView(ListAPIView):
+class AdvertisementCategoryListAPIView(ListAPIView):
     serializer_class = AdvertisementCategorySerializer
     permission_classes = [IsAuthenticatedAndIsActive]
-    queryset = Advertisement.objects.all()
+    queryset = AdvertisementCategory.objects.all()


### PR DESCRIPTION
Ранее в swagger'e и в url'aх не было endpoint'a для категорий. 

Была исправлена `AdvertisementCategoryListAPIView`, добавлен нужный serializer и `queryset`. Также данный endpoint был зарегистрирован в `urls.py`. 

Close #51 